### PR TITLE
Update sites.json 2

### DIFF
--- a/src/apis/data/sites.json
+++ b/src/apis/data/sites.json
@@ -1,8 +1,8 @@
 [
 	{
 		"name": "HTTP Status Codes",
-		"description": "httpstatuses.com is an easy to reference database of HTTP Status Codes with their definitions and helpful code references all in one place. ",
-		"url": "https://httpstatuses.com/",
+		"description": "http.dev is an easy to reference database of HTTP Status Codes with their definitions and helpful code references all in one place. ",
+		"url": "https://http.dev/status",
 		"repo": ""
 	},
 	{


### PR DESCRIPTION
httpstatuses.com does not exist anymore, redirects. http.dev/status has better overview with more code snippets/examples.